### PR TITLE
Fix Kramdown/Maruku parser bug.

### DIFF
--- a/codepen.rb
+++ b/codepen.rb
@@ -29,7 +29,7 @@ module Jekyll
 
     def render(context)
       if @pen && @user
-        "<pre class=\"codepen\" data-height=\"#{@height}\" data-type=\"#{@type}\" data-href=\"#{@pen}\" data-user=\"#{@user}\"><code></code></pre>\n<script async src=\"http://codepen.io:/assets/embed/ei.js\"></script>"
+        "<pre class=\"codepen\" data-height=\"#{@height}\" data-type=\"#{@type}\" data-href=\"#{@pen}\" data-user=\"#{@user}\"><code> </code></pre>\n<script async src=\"http://codepen.io:/assets/embed/ei.js\"></script>"
       else
         "Error processing input, expected syntax: {% codepen href user [type] [height] %}"
       end


### PR DESCRIPTION
The empty `<code></code>` would be transformed into `<code/>` by Maruku/Kramdown. So I added a space between them to prevent it from breaking the content following {% codepen... %} tag.
