### PR TITLE
Plugin 2.0 Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ This plugin adds a `{% codepen %}` Liquid tag to Jekyll and Octopress that gener
 
 Move `codepen.rb` into the `_plugins` folder at the root of your Octopress project.
 
-**Note:** This plugin does not include the CodePen script. You must include the following script elsewhere on your page:
+**Note:** This plugin does not include the CodePen script. You must include the CodePen script elsewhere on your page. I recommend using the follow snippet to include the script automatically on pages that include the CodePen widget.
 
-```html
-<script async src="//codepen.io/assets/embed/ei.js"></script>
+```liquid
+{% if page.content contains '<p class="codepen"' %}
+<!-- CodePen -->
+<script async src="//assets.codepen.io/assets/embed/ei.js"></script>
+{% endif %}
 ```
 
 # Syntax

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Move `codepen.rb` into the `_plugins` folder at the root of your Octopress proje
 **Note:** This plugin does not include the CodePen script. You must include the following script elsewhere on your page:
 
 ```html
-<script async src="http://codepen.io:/assets/embed/ei.js"></script>
+<script async src="//codepen.io/assets/embed/ei.js"></script>
 ```
 
 # Syntax

--- a/README.md
+++ b/README.md
@@ -56,3 +56,16 @@ rerun-position    | bottom right | top/left/right/bottom/hidden
 {% codepen xwder height:600 default-tab:css preview:true %}
 <p data-embed-version="2" data-height="600" data-default-tab="css" data-preview="true" data-slug-hash="xwder" class="codepen"></p>
 ```
+
+## Global Configuration
+
+Options may also be set globally by defining a `codepen` entry in the `_config.yml` file.
+
+```
+codepen:
+  theme-id: dark
+  show-tab-bar: false
+  rerun-position: hidden
+```
+
+**Note:** Inline options overwrite the global options.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,58 @@
 # Introduction
 
-This plugin adds a `{% codepen %}` tag to Jekyll/Octopress. It (surprisingly) embeds [CodePen](http://codepen.io)s. You can find an [example over at my personal blog](http://volker-rose.de/blog/2012/11/03/codepen-plugin-for-octopress/).
+This plugin adds a `{% codepen %}` Liquid tag to Jekyll and Octopress that generates a [CodePen](http://codepen.io) embed code.
 
 # Installation
 
-Move `codepen.rb` into the `plugins` folder at the root of your octopress repo.
+Move `codepen.rb` into the `_plugins` folder at the root of your Octopress project.
 
-# Syntax #
+**Note:** This plugin does not include the CodePen script. You must include the following script elsewhere on your page:
 
-	{% codepen href user [type] [height] %}
+```html
+<script async src="http://codepen.io:/assets/embed/ei.js"></script>
+```
 
-# Usage
+# Syntax
 
-    {% codepen vhfon riddla %}
+```liquid
+{% codepen slug-hash [data-attr:value]... %}
+```
 
-Option parameters, such as `{% codepen vhfon riddla css 400 %}` can be used.
+## Options
 
-## Allowed options
+All [CodePen embed attributes](https://blog.codepen.io/documentation/features/embedded-pens/) are configurable with this extension.
 
- * `type` - type of embed; defaults to `result`; other types are `css` and `js`
- * `height` - the height of the embedded iframe
+Parameter         | Default      | Notes                         
+------------------|--------------|-------------------------------
+theme-id          | 0            | Sets theme                    
+slug-hash         | none         | Required                      
+user              | none         | Not required                  
+default-tab       | result       | html/css/js/result            
+height            | 300          | Not a part of themes          
+show-tab-bar      | true         | true/false, **PRO only**      
+animations        | run          | run/stop-after-5              
+border            | none         | none/thin/thick               
+border-color      | #000000      | Hex Color Code                
+tab-bar-color     | #3d3d3e      | Hex Color Code                
+tab-link-color    | #76daff      | Hex Color Code                
+active-tab-color  | #cccccc      | Hex Color Code                
+active-link-color | #000000      | Hex Color Code                
+link-logo-color   | #ffffff      | Hex Color Code                
+class             | none         | Class added to embedded iframe
+custom-css-url    | none         | Style embed with custom CSS   
+preview           | false        | Displays static preview       
+rerun-position    | bottom right | top/left/right/bottom/hidden  
 
-# Credits
+**Note:** All parameters, except `slug-hash` (the first parameter) are optional. All default values are assigned by CodePen, not this plugin.
 
-This plugin was heavily inspired (e.g. shamelessly copied) from [Brian Arnolds jsFiddle Octopress plugin](http://brianarn.github.com/blog/2011/08/jsfiddle-plugin/).
+## Examples
+
+```
+{% codepen xwder %}
+<p data-embed-version="2" data-slug-hash="xwder" class="codepen"></p>
+```
+
+```
+{% codepen xwder height:600 default-tab:css preview:true %}
+<p data-embed-version="2" data-height="600" data-default-tab="css" data-preview="true" data-slug-hash="xwder" class="codepen"></p>
+```

--- a/codepen.rb
+++ b/codepen.rb
@@ -8,7 +8,7 @@
 # Link: https://blog.codepen.io/documentation/features/embedded-pens/
 #
 # Note: You must include the CodePen script elsewhere on your page:
-#   <script async src="http://codepen.io:/assets/embed/ei.js"></script>
+#   <script async src="//assets.codepen.io/assets/embed/ei.js"></script>
 #
 # Syntax: {% codepen slug-hash [data-attr:value]... %}
 #


### PR DESCRIPTION
With this update, you only have to define the pen's slug; the username and other plugin metadata is fetched automatically. This also allows users to specify any of the CodePen embed parameters to customize the look of the embed to match their site, and options can be specified globally to set the site's defaults.

This uses a slightly different syntax from the previous version, so it isn't backwards compatible.